### PR TITLE
Find and report all logic issues

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -51,6 +51,12 @@
               ],
               "outputHashing": "all"
             },
+            "gh-pages": {
+              "outputMode": "browser",
+              "baseHref": "./",
+              "deployUrl": "./",
+              "outputHashing": "all"
+            },
             "development": {
               "optimization": false,
               "extractLicenses": false,

--- a/projects/habit-buddy/public/404.html
+++ b/projects/habit-buddy/public/404.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting…</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="0; url=./">
+    <script>
+      /*
+       * SPA GitHub Pages 404 redirect
+       * Preserves path for client-side routers (Angular/React/Vue)
+       * Source concept: https://github.com/rafrex/spa-github-pages
+       */
+      (function(location) {
+        var path = location.pathname;
+        var search = location.search;
+        var hash = location.hash;
+
+        // Heuristic: keep first path segment for project pages (user.github.io/repo/...)
+        // If hosted at a user/organization page (no repo segment), this will still work.
+        var segments = path.replace(/^\/+|\/+$/g, '').split('/');
+        var keep = segments.length > 0 ? 1 : 0;
+        var newPath = (keep ? '/' + segments.slice(0, keep).join('/') : '') + '/?/' + segments.slice(keep).join('/');
+        var newUrl = newPath + (search ? (search.indexOf('?') === 0 ? '&' + search.slice(1) : search) : '') + hash;
+
+        location.replace(newUrl);
+      })(window.location);
+    </script>
+  </head>
+  <body>
+    Redirecting…
+  </body>
+  </html>
+

--- a/projects/habit-buddy/src/app/layout/components/header/header.component.html
+++ b/projects/habit-buddy/src/app/layout/components/header/header.component.html
@@ -1,10 +1,10 @@
 <header class="flex items-center justify-between">
   <div class="flex flex-row items-center">
     <img 
-      src="/logo/logo.svg" 
+      src="./logo/logo.svg" 
       alt="HabitBuddy" 
       class="w-10 h-10"
-      onerror="this.src='/logo/habitbuddy_vector_64.png'"
+      onerror="this.src='./logo/habitbuddy_vector_64.png'"
     />
     <span class="text-xs font-medium ml-2">HabitBuddy</span>
   </div>

--- a/projects/habit-buddy/src/app/layout/components/sidebar/sidebar.component.html
+++ b/projects/habit-buddy/src/app/layout/components/sidebar/sidebar.component.html
@@ -2,10 +2,10 @@
   <div class="mb-6">
     <div class="flex items-center mb-3">
       <img 
-        src="/logo/logo.svg" 
+        src="./logo/logo.svg" 
         alt="HabitBuddy" 
         class="w-12 h-12"
-        onerror="this.src='/logo/habitbuddy_vector_64.png'"
+        onerror="this.src='./logo/habitbuddy_vector_64.png'"
       />
       <h1 class="text-xl font-semibold ml-3">HabitBuddy</h1>
     </div>

--- a/projects/habit-buddy/src/index.html
+++ b/projects/habit-buddy/src/index.html
@@ -3,9 +3,20 @@
 <head>
   <meta charset="utf-8">
   <title>HabitBuddy - Responsive Desktop & Mobile</title>
-  <base href="/">
+  <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="./logo/logo.svg">
+  
+  <script>
+    (function () {
+      var l = window.location;
+      if (l.search && l.search.indexOf('?/') === 0) {
+        var path = l.search.slice(2).split('&')[0];
+        var newUrl = (l.pathname.replace(/index\.html$/, '')) + path + l.hash;
+        window.history.replaceState(null, '', newUrl);
+      }
+    })();
+  </script>
   
   <!-- External dependencies -->
   <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
Add GitHub Pages SPA fallback and adjust base href/asset paths to fix 404 errors on deep links.

GitHub Pages serves `404.html` for non-existent paths. This PR leverages that by adding a `404.html` that redirects to `index.html` while preserving the original URL path, allowing Angular's router to handle it. Additionally, `base href` and asset paths are made relative to ensure correct loading when deployed to a repository subpath. A dedicated `gh-pages` build configuration is also introduced for easier deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-d575a57e-42a4-4391-8da0-dc2269e247fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d575a57e-42a4-4391-8da0-dc2269e247fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

